### PR TITLE
Add ECR Docker registry for jenkins-x

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Most important elements of the environment:
 
 * VPC (not created by this module, must exist apriori as it can be only created with a portal)
 * Kubernetes cluster (to be used for CI/CD, monitoring, etc.)
+* ECR Docker registry
 * VPC Endpoint - kinesis-streams service (Interface type)
 * kinesis stream (logging)
 * elasticsearch domain (logging)

--- a/main.tf
+++ b/main.tf
@@ -28,3 +28,8 @@ module "kubernetes_cluster_operations" {
   masters_iam_policies_arns = "${var.k8s_masters_iam_policies_arns}"
   nodes_iam_policies_arns   = "${var.k8s_nodes_iam_policies_arns}"
 }
+
+# ECR registry for customized JenkinsX image:
+resource "aws_ecr_repository" "jenkins-x-image" {
+  name = "jenkins-x-image"
+}


### PR DESCRIPTION
This is needed for customized Docker images for jenkins-x that are needed (otherwise we would have to depend on external service for building images e.g. DockerHub).