### PR TITLE
Add support for Amazon Linux 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,4 @@ module "operations" {
 | k8s\_nodes\_iam\_policies\_arns | List of existing IAM policies that will be attached to instance profile for worker nodes (EC2 instances) | list | n/a | yes |
 | http\_proxy | IP[:PORT] - address and optional port of HTTP proxy to be used to download packages | string | n/a | yes |
 | k8s\_aws\_ssh\_keypair\_name | Optional name of existing SSH keypair on AWS account, to be used for cluster instances (will be generated if not specified) | string | `""` | no |
+| k8s_linux_distro | Linux distribution for K8s cluster instances (supported values: debian, amzn2) | string | `amzn2` | no |

--- a/README.md
+++ b/README.md
@@ -80,4 +80,4 @@ module "operations" {
 | k8s\_nodes\_iam\_policies\_arns | List of existing IAM policies that will be attached to instance profile for worker nodes (EC2 instances) | list | n/a | yes |
 | http\_proxy | IP[:PORT] - address and optional port of HTTP proxy to be used to download packages | string | n/a | yes |
 | k8s\_aws\_ssh\_keypair\_name | Optional name of existing SSH keypair on AWS account, to be used for cluster instances (will be generated if not specified) | string | `""` | no |
-| k8s_linux_distro | Linux distribution for K8s cluster instances (supported values: debian, amzn2) | string | `amzn2` | no |
+| k8s_linux_distro | Linux distribution for K8s cluster instances (supported values: debian, amzn2) | string | `debian` | no |

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,7 @@ module "kubernetes_cluster_operations" {
   master_instance_type = "${var.k8s_master_instance_type}"
   node_instance_type   = "${var.k8s_node_instance_type}"
   aws_ssh_keypair_name = "${var.k8s_aws_ssh_keypair_name}"
+  linux_distro         = "${var.k8s_linux_distro}"
 
   masters_iam_policies_arns = "${var.k8s_masters_iam_policies_arns}"
   nodes_iam_policies_arns   = "${var.k8s_nodes_iam_policies_arns}"

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
 
 # Kubernetes cluster:
 module "kubernetes_cluster_operations" {
-  source = "github.com/kentrikos/terraform-aws-kops"
+  source = "github.com/kentrikos/terraform-aws-kops?ref=amzn2-ami"
 
   cluster_name_prefix = "${var.product_domain_name}-${var.environment_type}-ops"
   region              = "${var.region}"

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ locals {
 
 # Kubernetes cluster:
 module "kubernetes_cluster_operations" {
-  source = "github.com/kentrikos/terraform-aws-kops?ref=amzn2-ami"
+  source = "github.com/kentrikos/terraform-aws-kops"
 
   cluster_name_prefix = "${var.product_domain_name}-${var.environment_type}-ops"
   region              = "${var.region}"

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "k8s_nodes_iam_policies_arns" {
 
 variable "k8s_linux_distro" {
   description = "Linux distribution for K8s cluster instances (supported values: debian, amzn2)"
-  default     = "amzn2"
+  default     = "debian"
 }
 
 variable "http_proxy" {

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,11 @@ variable "k8s_nodes_iam_policies_arns" {
   type        = "list"
 }
 
+variable "k8s_linux_distro" {
+  description = "Linux distribution for K8s cluster instances (supported values: debian, amzn2)"
+  default     = "amzn2"
+}
+
 variable "http_proxy" {
   description = "IP[:PORT] - address and optional port of HTTP proxy to be used to download packages"
 }


### PR DESCRIPTION
Based on new feature in kops module: https://github.com/kentrikos/terraform-aws-kops/pull/6